### PR TITLE
Upgrade Eigen dependency to Eigen3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   visualization_msgs)
 
 find_package(
-  Eigen REQUIRED)
+  Eigen3 REQUIRED)
 
 find_package(
   octomap REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ catkin_package(
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-  ${Eigen_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIR}
   ${OCTOMAP_INCLUDE_DIRS}
 )
 


### PR DESCRIPTION
Without this fix, we get the following warnings while building in Melodic and later. I'm worried that Noetic/Ubuntu 20 may drop support for `find_package(Eigen)`.

```
_______________________________________________________________________________
Warnings   << mapper:check /home/adam/catkin_ws/logs/mapper/build.check.011.log
CMake Warning at /opt/ros/melodic/share/cmake_modules/cmake/Modules/FindEigen.cmake:62 (message):
  The FindEigen.cmake Module in the cmake_modules package is deprecated.

  Please use the FindEigen3.cmake Module provided with Eigen.  Change
  instances of find_package(Eigen) to find_package(Eigen3).  Check the
  FindEigen3.cmake Module for the resulting CMake variable names.

Call Stack (most recent call first):
  CMakeLists.txt:24 (find_package)


cd /home/adam/catkin_ws/build/mapper; catkin build --get-env mapper | catkin env -si  /usr/bin/make cmake_check_build_system; cd -
...............................................................................

```