### PR TITLE
Upgrade Eigen3 DEPENDS directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ roslint_cpp()
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  DEPENDS Eigen
+  INCLUDE_DIRS include
+  DEPENDS EIGEN3
   CATKIN_DEPENDS
     cmake_modules
     roscpp


### PR DESCRIPTION
This fix prevents the following build warning from appearing (aftermath of #7):

```
Starting  >>> mapper                                                           
_______________________________________________________________________________
Warnings   << mapper:cmake /home/adam/catkin_ws/logs/mapper/build.cmake.005.log
CMake Warning at /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'Eigen' but neither 'Eigen_INCLUDE_DIRS' nor
  'Eigen_LIBRARIES' is defined.
Call Stack (most recent call first):
  /opt/ros/melodic/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:44 (catkin_package)


cd /home/adam/catkin_ws/build/mapper; catkin build --get-env mapper | catkin env -si  /usr/bin/cmake /home/adam/catkin_ws/src/pensa/third_party/mapper --no-warn-unused-cli -DCATKIN_DEVEL_PREFIX=/home/adam/catkin_ws/devel/.private/mapper -DCMAKE_INSTALL_PREFIX=/home/adam/catkin_ws/install -DCMAKE_BUILD_TYPE=Release; cd -
...............................................................................
Finished  <<< mapper                [ 35.0 seconds ]         
```